### PR TITLE
correct variant path to work on case-sensitive systems

### DIFF
--- a/Gen7/avr/boards.txt
+++ b/Gen7/avr/boards.txt
@@ -18,7 +18,7 @@ Gen7.bootloader.lock_bits=0x0F
 
 Gen7.build.board=AVR_GEN7
 Gen7.build.core=arduino:arduino
-Gen7.build.variant=gen7
+Gen7.build.variant=Gen7
 
 ###### ATmega644
 


### PR DESCRIPTION
see comment. thx for the adaptation to arduino, works also on 1.8.x